### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/aflow.3.1.212/README_AFLOW_ACONVASP.TXT
+++ b/aflow.3.1.212/README_AFLOW_ACONVASP.TXT
@@ -1616,11 +1616,11 @@ LATTICES = (the ones with "")
   
   aflow --lattice_type | --lattice | --lattice_crystal < POSCAR
         Returns the lattice type and the conventional lattice type of the CRYSTAL following the tables
-        of Setyawayn-Curtarolo [http://dx.doi.org/10.1016/j.commatsci.2010.05.010].
+        of Setyawayn-Curtarolo [https://doi.org/10.1016/j.commatsci.2010.05.010].
         Check aflow --readme=symmetry
   aflow --lattice_lattice_type | --lattice_lattice < POSCAR
         Returns the lattice type and the conventional lattice type of the LATTICE following the tables
-        of Setyawayn-Curtarolo [http://dx.doi.org/10.1016/j.commatsci.2010.05.010].
+        of Setyawayn-Curtarolo [https://doi.org/10.1016/j.commatsci.2010.05.010].
         Check aflow --readme=symmetry
   aflow --latticehistogram < POSCAR
         Outputs the lattice calculated respect to tolerance of histogram of symmetry.

--- a/aflow.3.1.212/README_AFLOW_SYM.TXT
+++ b/aflow.3.1.212/README_AFLOW_SYM.TXT
@@ -380,11 +380,11 @@ AFLOW COMMANDS USAGE:
   
   aflow --lattice_type | --lattice | --lattice_crystal < POSCAR
         Returns the lattice type and the conventional lattice type of the CRYSTAL following the tables
-        of Setyawayn-Curtarolo [http://dx.doi.org/10.1016/j.commatsci.2010.05.010].
+        of Setyawayn-Curtarolo [https://doi.org/10.1016/j.commatsci.2010.05.010].
 
   aflow --lattice_lattice_type | --lattice_lattice < POSCAR
         Returns the lattice type and the conventional lattice type of the LATTICE following the tables
-        of Setyawayn-Curtarolo [http://dx.doi.org/10.1016/j.commatsci.2010.05.010].
+        of Setyawayn-Curtarolo [https://doi.org/10.1016/j.commatsci.2010.05.010].
   
   aflow --pearson_symbol | --pearson < POSCAR
         Returns the Pearson symbol of the structure.

--- a/aflow.3.1.212/aflowlib_web_outreach.cpp
+++ b/aflow.3.1.212/aflowlib_web_outreach.cpp
@@ -12,7 +12,7 @@
 #define TOC 0
 
 #define WEB_PDF  string("http://"+XHOST.AFLOW_MATERIALS_SERVER+"/auro/AUROARTICULA/")
-#define WEB_DOI  string("http://dx.doi.org/")
+#define WEB_DOI  string("https://doi.org/")
 
 #define THRUST_RECENT_ARTICLES  20
 #define THRUST_RECENT_YEARS     5
@@ -248,7 +248,7 @@ ostream& operator<<(ostream& oss,const _outreach& outreach) {
       if(XHOST.vflag_control.flag("PRINT_MODE::DOI") && outreach.doi.length()>0) {
 	string doi="";
 	doi="\\ifthenelse{\\equal{\\hyperlinks}{true}}{";
-	doi+="{\\newline \\sf \\href{http://dx.doi.org/"+outreach.doi+"}{DOI: "+aurostd::html2latex(outreach.doi)+"}}";
+	doi+="{\\newline \\sf \\href{https://doi.org/"+outreach.doi+"}{DOI: "+aurostd::html2latex(outreach.doi)+"}}";
 	doi+="}{{\\newline \\sf DOI: "+aurostd::html2latex(outreach.doi)+"}}";
 	oss << " " << doi;
 	link=TRUE;
@@ -256,7 +256,7 @@ ostream& operator<<(ostream& oss,const _outreach& outreach) {
 	if(outreach.wnumber!=0 && outreach.wnumber!=27 && outreach.wnumber!=14 &&
 	   outreach.wnumber!=11 && outreach.wnumber!=8 && outreach.wnumber!=2 &&
 	   outreach.wnumber!=1) {
-	  string doi=""; // ="{\\newline \\sf \\href{http://dx.doi.org/}{DOI: N/A}}";
+	  string doi=""; // ="{\\newline \\sf \\href{https://doi.org/}{DOI: N/A}}";
 	  oss << " " << doi;
 	  link=TRUE;
 	}

--- a/readme/README_AFLOW_ACONVASP.TXT
+++ b/readme/README_AFLOW_ACONVASP.TXT
@@ -1616,11 +1616,11 @@ LATTICES = (the ones with "")
   
   aflow --lattice_type | --lattice | --lattice_crystal < POSCAR
         Returns the lattice type and the conventional lattice type of the CRYSTAL following the tables
-        of Setyawayn-Curtarolo [http://dx.doi.org/10.1016/j.commatsci.2010.05.010].
+        of Setyawayn-Curtarolo [https://doi.org/10.1016/j.commatsci.2010.05.010].
         Check aflow --readme=symmetry
   aflow --lattice_lattice_type | --lattice_lattice < POSCAR
         Returns the lattice type and the conventional lattice type of the LATTICE following the tables
-        of Setyawayn-Curtarolo [http://dx.doi.org/10.1016/j.commatsci.2010.05.010].
+        of Setyawayn-Curtarolo [https://doi.org/10.1016/j.commatsci.2010.05.010].
         Check aflow --readme=symmetry
   aflow --latticehistogram < POSCAR
         Outputs the lattice calculated respect to tolerance of histogram of symmetry.

--- a/readme/README_AFLOW_SYM.TXT
+++ b/readme/README_AFLOW_SYM.TXT
@@ -380,11 +380,11 @@ AFLOW COMMANDS USAGE:
   
   aflow --lattice_type | --lattice | --lattice_crystal < POSCAR
         Returns the lattice type and the conventional lattice type of the CRYSTAL following the tables
-        of Setyawayn-Curtarolo [http://dx.doi.org/10.1016/j.commatsci.2010.05.010].
+        of Setyawayn-Curtarolo [https://doi.org/10.1016/j.commatsci.2010.05.010].
 
   aflow --lattice_lattice_type | --lattice_lattice < POSCAR
         Returns the lattice type and the conventional lattice type of the LATTICE following the tables
-        of Setyawayn-Curtarolo [http://dx.doi.org/10.1016/j.commatsci.2010.05.010].
+        of Setyawayn-Curtarolo [https://doi.org/10.1016/j.commatsci.2010.05.010].
   
   aflow --pearson_symbol | --pearson < POSCAR
         Returns the Pearson symbol of the structure.


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected. So, there is no urgency here.

However, for consistency, this PRs suggests to update all static DOI links accordingly, plus the code that generates new DOI links.

Cheers!